### PR TITLE
conf: two modifications. (1) if Sphinx version is greater than 1.8, i…

### DIFF
--- a/pysphinxdoc/resources/conf.py
+++ b/pysphinxdoc/resources/conf.py
@@ -16,6 +16,11 @@ import sphinx
 if LooseVersion(sphinx.__version__) < LooseVersion("1"):
     raise RuntimeError("Need sphinx >= 1 for autodoc to work correctly.")
 
+if LooseVersion(sphinx.__version__) < LooseVersion("1.8"):
+    sphinx_math = "sphinx.ext.pngmath"
+else:
+    sphinx_math = "sphinx.ext.imgmath"
+
 # -- General configuration --------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -98,7 +103,8 @@ release = version
 # for source files.
 exclude_patterns = [
     "examples",
-    templates_path,
+    templates_path[0],
+    templates_path[1],
     os.path.join("scikit-learn", "static", "ML_MAPS_README.rst")]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/pysphinxdoc/resources/conf.py
+++ b/pysphinxdoc/resources/conf.py
@@ -36,7 +36,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.pngmath",
+    sphinx_math,
     "sphinx.ext.ifconfig",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",

--- a/pysphinxdoc/sphinxext/numpy_ext/numpydoc.py
+++ b/pysphinxdoc/sphinxext/numpy_ext/numpydoc.py
@@ -29,7 +29,10 @@ if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
 from .docscrape_sphinx import get_doc_object, SphinxDocString
-from sphinx.util.compat import Directive
+try:
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive
 
 if sys.version_info[0] >= 3:
     sixu = lambda s: s


### PR DESCRIPTION
…t's better to use sphinx.ext.imgmath (sphinx.ext.pngmath is deprecated). (2) To use 'startswith' on each pattern, 'exclude_patterns' must be a list and not a list of list.